### PR TITLE
feat: add pedestrian sign filtering to Road Signs quiz and UI

### DIFF
--- a/client/src/components/RoadSignGallery.tsx
+++ b/client/src/components/RoadSignGallery.tsx
@@ -116,20 +116,28 @@ const RoadSignGallery: React.FC<RoadSignGalleryProps> = ({ roadSigns, isLoading 
               <div className="flex-1 p-4">
                 <p className="text-sm text-gray-600 mb-2">{roadSign.description || 'No description available'}</p>
                 
-                {roadSign.googleMapsUrl && (
-                  <a 
-                    href={roadSign.googleMapsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center text-sm text-blue-600 hover:text-blue-800"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <svg className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                    </svg>
-                    View on Google Maps
-                  </a>
-                )}
+                <div className="flex items-center flex-wrap gap-2">
+                  {roadSign.isPedestrian && (
+                    <span className="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full font-medium">
+                      Pedestrian
+                    </span>
+                  )}
+                  
+                  {roadSign.googleMapsUrl && (
+                    <a 
+                      href={roadSign.googleMapsUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center text-sm text-blue-600 hover:text-blue-800"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <svg className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                      </svg>
+                      View on Google Maps
+                    </a>
+                  )}
+                </div>
               </div>
             </div>
           </div>
@@ -197,21 +205,34 @@ const RoadSignGallery: React.FC<RoadSignGalleryProps> = ({ roadSigns, isLoading 
                 })()}
               </div>
               
-              <div className="mb-4">
-                <h4 className="text-sm font-semibold text-gray-700 mb-2">Location</h4>
-                <a 
-                  href={selectedRoadSign.googleMapsUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="text-blue-600 hover:text-blue-800 flex items-center"
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-                  </svg>
-                  View on Google Maps
-                </a>
-              </div>
+              {/* Type section */}
+              {selectedRoadSign.isPedestrian && (
+                <div className="mb-4">
+                  <h4 className="text-sm font-semibold text-gray-700 mb-2">Type</h4>
+                  <span className="inline-block bg-green-100 text-green-800 text-sm px-3 py-1 rounded-full font-medium">
+                    Pedestrian Sign
+                  </span>
+                </div>
+              )}
+              
+              {/* Location section - only show if Google Maps URL exists */}
+              {selectedRoadSign.googleMapsUrl && (
+                <div className="mb-4">
+                  <h4 className="text-sm font-semibold text-gray-700 mb-2">Location</h4>
+                  <a 
+                    href={selectedRoadSign.googleMapsUrl} 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:text-blue-800 flex items-center"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                    View on Google Maps
+                  </a>
+                </div>
+              )}
               
               <div className="mt-6 text-center text-sm text-gray-500">
                 Press ESC key or click outside to close

--- a/client/src/pages/QuizSettingsPage.tsx
+++ b/client/src/pages/QuizSettingsPage.tsx
@@ -24,6 +24,7 @@ const QuizSettingsPage: React.FC<QuizSettingsPageProps> = () => {
   const [onlyGeoGuessr, setOnlyGeoGuessr] = useState<boolean>(false);
   const [writeMode, setWriteMode] = useState<boolean>(false);
   const [blurred, setBlurred] = useState<boolean>(false);
+  const [pedestrianSigns, setPedestrianSigns] = useState<boolean>(false);
   const [continents, setContinents] = useState<string[]>([
     'Africa', 'Asia', 'Europe', 'North America', 'South America', 'Oceania', 'Antarctica'
   ]);
@@ -63,6 +64,7 @@ const QuizSettingsPage: React.FC<QuizSettingsPageProps> = () => {
         setSelectedContinent(savedSettings.continent || 'all');
         setOnlyGeoGuessr(savedSettings.in_geoguessr || false);
         setBlurred(savedSettings.blurred || false);
+        setPedestrianSigns(savedSettings.pedestrianSigns || false);
         
         // Mark initial load as complete
         initialLoadCompleted.current = true;
@@ -103,13 +105,14 @@ const QuizSettingsPage: React.FC<QuizSettingsPageProps> = () => {
         writeMode,
         continent: selectedContinent,
         in_geoguessr: onlyGeoGuessr,
-        blurred
+        blurred,
+        pedestrianSigns
       };
       
       saveSettings(quizType as QuizType, currentSettings);
       console.log('Settings saved:', currentSettings);
     }
-  }, [quizType, timerEnabled, timerDuration, questionCount, writeMode, selectedContinent, onlyGeoGuessr, blurred]);
+  }, [quizType, timerEnabled, timerDuration, questionCount, writeMode, selectedContinent, onlyGeoGuessr, blurred, pedestrianSigns]);
   
   // Fetch continents on component mount
   useEffect(() => {
@@ -162,6 +165,11 @@ const QuizSettingsPage: React.FC<QuizSettingsPageProps> = () => {
             params.in_geoguessr = true;
           }
           
+          // Add pedestrian signs filter for road signs
+          if (quizType === 'roadsigns' && pedestrianSigns) {
+            params.pedestrian = true;
+          }
+          
           const response = await axios.get(endpoint, { params });
           
           if (response.data && response.data.success) {
@@ -198,7 +206,7 @@ const QuizSettingsPage: React.FC<QuizSettingsPageProps> = () => {
     if (initialLoadCompleted.current || initialLoadStarted.current) {
       fetchMaxQuestionCount();
     }
-  }, [quizType, selectedContinent, onlyGeoGuessr, questionCount]);
+  }, [quizType, selectedContinent, onlyGeoGuessr, pedestrianSigns, questionCount]);
   
   const handleStartQuiz = () => {
     // Initialize a new quiz session with filters and settings
@@ -206,7 +214,8 @@ const QuizSettingsPage: React.FC<QuizSettingsPageProps> = () => {
       state: { 
         filters: {
           continent: selectedContinent,
-          in_geoguessr: onlyGeoGuessr  // Using snake_case to match server convention
+          in_geoguessr: onlyGeoGuessr,  // Using snake_case to match server convention
+          pedestrian: quizType === 'roadsigns' ? pedestrianSigns : undefined
         },
         settings: {
           timerEnabled,
@@ -329,6 +338,29 @@ const QuizSettingsPage: React.FC<QuizSettingsPageProps> = () => {
                   Blurred
                 </label>
               </div>
+            </div>
+          )}
+          
+          {/* Sign Type Section - Only for road signs quiz */}
+          {quizConfig.type === 'roadsigns' && (
+            <div className="mb-6">
+              <h3 className="text-lg font-medium text-gray-700 mb-3">Sign Type</h3>
+              
+              <div className="flex items-center">
+                <input
+                  type="checkbox"
+                  id="pedestrian-signs-toggle"
+                  checked={pedestrianSigns}
+                  onChange={(e) => setPedestrianSigns(e.target.checked)}
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                />
+                <label htmlFor="pedestrian-signs-toggle" className="ml-2 block text-sm font-medium text-gray-700">
+                  Pedestrian Signs
+                </label>
+              </div>
+              <p className="mt-1 ml-6 text-sm text-gray-500">
+                Only show pedestrian-related road signs
+              </p>
             </div>
           )}
           

--- a/client/src/pages/RoadSignsPage.tsx
+++ b/client/src/pages/RoadSignsPage.tsx
@@ -17,6 +17,7 @@ interface ApiRoadSign {
   }[];
   createdAt: string;
   updatedAt: string;
+  isPedestrian?: boolean;
   __v: number;
 }
 
@@ -30,6 +31,7 @@ interface RoadSign {
   imageUrl: string;
   description: string;
   googleMapsUrl: string;
+  isPedestrian?: boolean;
 }
 
 // Define FilterSettings type at the top with other interfaces
@@ -185,7 +187,8 @@ const transformRoadSign = (roadSign: ApiRoadSign): RoadSign => {
     continent: continent,
     imageUrl: roadSign.imageUrl,
     description: roadSign.description,
-    googleMapsUrl: roadSign.googleMapsUrl
+    googleMapsUrl: roadSign.googleMapsUrl,
+    isPedestrian: roadSign.isPedestrian
   };
 };
 
@@ -777,6 +780,11 @@ const RoadSignsPage: React.FC = () => {
                 <p className="text-sm text-gray-600 mb-3">{sign.description}</p>
                 <div className="flex flex-wrap gap-2 mt-2">
                   <ContinentBadge continent={sign.continent} />
+                  {sign.isPedestrian && (
+                    <span className="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full font-medium">
+                      Pedestrian
+                    </span>
+                  )}
                   {sign.countryCode && (
                     <span className="inline-block bg-gray-100 text-gray-600 text-xs px-2 py-1 rounded-full font-medium uppercase">
                       {sign.countryCode}
@@ -806,6 +814,9 @@ const RoadSignsPage: React.FC = () => {
                 </th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Continent
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Type
                 </th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Map
@@ -851,15 +862,24 @@ const RoadSignsPage: React.FC = () => {
                     <ContinentBadge continent={sign.continent} />
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <a
-                      href={sign.googleMapsUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-500 hover:underline"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      View
-                    </a>
+                    {sign.isPedestrian && (
+                      <span className="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full font-medium">
+                        Pedestrian
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    {sign.googleMapsUrl ? (
+                      <a
+                        href={sign.googleMapsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-500 hover:underline"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        View
+                      </a>
+                    ) : null}
                   </td>
                 </tr>
               ))}
@@ -950,6 +970,15 @@ const RoadSignsPage: React.FC = () => {
                   <ContinentBadge continent={selectedRoadSign.continent} />
                 </div>
               </div>
+              
+              {selectedRoadSign.isPedestrian && (
+                <div className="mb-4">
+                  <h4 className="text-sm font-semibold text-gray-700 mb-2">Type</h4>
+                  <span className="inline-block bg-green-100 text-green-800 text-sm px-3 py-1 rounded-full font-medium">
+                    Pedestrian Sign
+                  </span>
+                </div>
+              )}
               
               {selectedRoadSign.googleMapsUrl && (
                 <div className="mb-4">

--- a/client/src/services/countryService.ts
+++ b/client/src/services/countryService.ts
@@ -37,6 +37,7 @@ export interface RoadSign {
   countries: (string | { _id: string; name: string; code?: string; flagUrl?: string })[];
   createdAt: string;
   updatedAt: string;
+  isPedestrian?: boolean;
 }
 
 export const fetchCountryDetails = async (countryName: string, initialFlagUrl?: string): Promise<CountryInfo> => {

--- a/client/src/types/quiz.ts
+++ b/client/src/types/quiz.ts
@@ -5,6 +5,7 @@ export type QuizType = 'flags' | 'capitals' | 'bollards' | 'licenseplates' | 'ro
 export interface QuizFilters {
   continent?: string;
   in_geoguessr?: boolean;
+  pedestrian?: boolean;
   [key: string]: any;
 }
 

--- a/client/src/utils/settingsStorage.ts
+++ b/client/src/utils/settingsStorage.ts
@@ -10,6 +10,7 @@ export interface QuizSettings {
   in_geoguessr?: boolean;
   blurred?: boolean;
   blurIntensity?: number;
+  pedestrianSigns?: boolean;
 }
 
 // The key used to store all settings in localStorage
@@ -25,7 +26,8 @@ const DEFAULT_SETTINGS: Record<QuizType, QuizSettings> = {
     continent: 'all',
     in_geoguessr: false,
     blurred: false,
-    blurIntensity: 15
+    blurIntensity: 15,
+    pedestrianSigns: false
   },
   capitals: {
     timerEnabled: true,
@@ -35,7 +37,8 @@ const DEFAULT_SETTINGS: Record<QuizType, QuizSettings> = {
     continent: 'all',
     in_geoguessr: false,
     blurred: false,
-    blurIntensity: 15
+    blurIntensity: 15,
+    pedestrianSigns: false
   },
   bollards: {
     timerEnabled: true,
@@ -45,7 +48,8 @@ const DEFAULT_SETTINGS: Record<QuizType, QuizSettings> = {
     continent: 'all',
     in_geoguessr: false,
     blurred: false,
-    blurIntensity: 15
+    blurIntensity: 15,
+    pedestrianSigns: false
   },
   licenseplates: {
     timerEnabled: true,
@@ -55,7 +59,8 @@ const DEFAULT_SETTINGS: Record<QuizType, QuizSettings> = {
     continent: 'all',
     in_geoguessr: false,
     blurred: false,
-    blurIntensity: 15
+    blurIntensity: 15,
+    pedestrianSigns: false
   },
   roadsigns: {
     timerEnabled: true,
@@ -65,7 +70,8 @@ const DEFAULT_SETTINGS: Record<QuizType, QuizSettings> = {
     continent: 'all',
     in_geoguessr: false,
     blurred: false,
-    blurIntensity: 15
+    blurIntensity: 15,
+    pedestrianSigns: false
   }
 };
 

--- a/server/src/controllers/quiz/generators/roadSignQuestions.ts
+++ b/server/src/controllers/quiz/generators/roadSignQuestions.ts
@@ -46,6 +46,15 @@ export async function getRandomRoadSignQuestion(filters?: QuizFilters, previousE
     });
   }
   
+  // Add pedestrian filter if specified
+  if (filters?.pedestrian) {
+    pipeline.push({
+      $match: {
+        isPedestrian: true
+      }
+    });
+  }
+  
   // Filter out road signs that were used in previous questions
   if (previousEntityIds.length > 0) {
     console.log(`Attempting to exclude ${previousEntityIds.length} previous road sign entities`);

--- a/server/src/controllers/quiz/questionController.ts
+++ b/server/src/controllers/quiz/questionController.ts
@@ -20,7 +20,38 @@ export const getNextQuestion = async (req: Request, res: Response) => {
   try {
     const { quizType } = req.params;
     const sessionId = req.query.sessionId as string || uuidv4();
-    const filters = req.query.filters ? JSON.parse(req.query.filters as string) as QuizFilters : undefined;
+    
+    // Extract filters from query parameters
+    let filters: QuizFilters | undefined;
+    
+    // First check if filters are explicitly provided as JSON
+    if (req.query.filters) {
+      filters = JSON.parse(req.query.filters as string) as QuizFilters;
+    } 
+    // Otherwise, extract individual filter parameters from query
+    else {
+      const continent = req.query.continent as string;
+      const in_geoguessr = req.query.in_geoguessr === 'true';
+      const pedestrian = req.query.pedestrian === 'true';
+      
+      // Only create filters object if at least one filter is present
+      if (continent || in_geoguessr || pedestrian) {
+        filters = {};
+        
+        if (continent && continent !== 'all') {
+          filters.continent = continent;
+        }
+        
+        if (in_geoguessr) {
+          filters.in_geoguessr = in_geoguessr;
+        }
+        
+        if (pedestrian) {
+          filters.pedestrian = pedestrian;
+        }
+      }
+    }
+    
     const previousQuestionIds = req.query.previousQuestionIds 
       ? JSON.parse(req.query.previousQuestionIds as string) as string[] 
       : [];

--- a/server/src/controllers/quiz/types.ts
+++ b/server/src/controllers/quiz/types.ts
@@ -6,6 +6,7 @@ import { QuizType } from '../../models/QuizResult';
 export interface QuizFilters {
   continent?: string;
   in_geoguessr?: boolean;
+  pedestrian?: boolean;
   [key: string]: any;
 }
 

--- a/server/src/controllers/roadSignController.ts
+++ b/server/src/controllers/roadSignController.ts
@@ -184,10 +184,11 @@ export const deleteRoadSign = async (req: Request, res: Response): Promise<void>
 
 export const getRoadSignCount = async (req: Request, res: Response): Promise<void> => {
     try {
-        const { continent, in_geoguessr } = req.query;
+        const { continent, in_geoguessr, pedestrian } = req.query;
         
         // Build a more sophisticated query based on filters
         let countryQuery: any = {};
+        let signQuery: any = {};
         
         // If continent filter is applied, find countries in that continent
         if (continent && continent !== 'all') {
@@ -197,6 +198,11 @@ export const getRoadSignCount = async (req: Request, res: Response): Promise<voi
         // If GeoGuessr filter is applied, find countries in GeoGuessr
         if (in_geoguessr === 'true') {
             countryQuery.in_geoguessr = true;
+        }
+        
+        // If pedestrian filter is applied
+        if (pedestrian === 'true') {
+            signQuery.isPedestrian = true;
         }
         
         // Find countries matching all applied filters
@@ -216,10 +222,22 @@ export const getRoadSignCount = async (req: Request, res: Response): Promise<voi
                 return;
             }
             
+            // Create the final query by combining country and sign filters
+            let finalQuery: any = {
+                countries: { $in: countryIds },
+                ...signQuery
+            };
+            
             // Find road signs where at least one of the associated countries matches the filter
-            const count = await RoadSign.countDocuments({
-                countries: { $in: countryIds }
+            const count = await RoadSign.countDocuments(finalQuery);
+            
+            res.status(200).json({
+                success: true,
+                count
             });
+        } else if (Object.keys(signQuery).length > 0) {
+            // Only sign filters applied (like pedestrian)
+            const count = await RoadSign.countDocuments(signQuery);
             
             res.status(200).json({
                 success: true,

--- a/server/src/tests/roadSignQuestions.test.ts
+++ b/server/src/tests/roadSignQuestions.test.ts
@@ -48,6 +48,25 @@ const mockAsianRoadSign = {
   ]
 };
 
+// Mock data for a pedestrian road sign
+const mockPedestrianRoadSign = {
+  _id: 'roadsign-3',
+  imageUrl: 'https://example.com/roadsign3.jpg',
+  description: 'A pedestrian crossing sign',
+  googleMapsUrl: 'https://maps.google.com/?q=Berlin',
+  isPedestrian: true,
+  countries: [
+    {
+      _id: 'country-3',
+      name: 'Germany',
+      capital: 'Berlin',
+      continent: 'Europe',
+      in_geoguessr: true,
+      code: 'de'
+    }
+  ]
+};
+
 // Mock the RoadSign and Country models
 jest.mock('../models/RoadSign', () => ({
   aggregate: jest.fn(),
@@ -194,5 +213,136 @@ describe('Road Sign Questions Generator', () => {
     expect(question.metadata).toBeDefined();
     expect(question.metadata?.allCorrectCountryNames).toEqual(['Japan']);
     expect(question.metadata?.roadSignId).toBe('roadsign-2');
+  });
+
+  test('should apply pedestrian filter correctly', async () => {
+    // Mock the RoadSign.aggregate function for this specific test
+    (RoadSign.aggregate as jest.Mock).mockResolvedValue([mockPedestrianRoadSign]);
+
+    // Mock the Country.aggregate function for incorrect options
+    (Country.aggregate as jest.Mock).mockResolvedValue([
+      {
+        _id: 'country-1',
+        name: 'France',
+        capital: 'Paris',
+        continent: 'Europe',
+        in_geoguessr: true,
+        code: 'fr'
+      },
+      {
+        _id: 'country-2',
+        name: 'Belgium',
+        capital: 'Brussels',
+        continent: 'Europe',
+        in_geoguessr: true,
+        code: 'be'
+      },
+      {
+        _id: 'country-4',
+        name: 'Italy',
+        capital: 'Rome',
+        continent: 'Europe',
+        in_geoguessr: true,
+        code: 'it'
+      }
+    ]);
+
+    // Define filter for pedestrian signs
+    const filters: QuizFilters = {
+      pedestrian: true
+    };
+
+    // Call the function being tested with pedestrian filter
+    const question = await getRandomRoadSignQuestion(filters);
+
+    // Assertions
+    expect(question).toBeDefined();
+    expect(question.question).toBe('Which country does this road sign belong to?');
+    expect(question.imageUrl).toBe('https://example.com/roadsign3.jpg');
+    expect(question.options.length).toBe(4);
+    
+    // Check that one option is correct
+    const correctOptions = question.options.filter(option => option.isCorrect);
+    expect(correctOptions.length).toBe(1);
+    
+    // The correct option should be Germany
+    const correctOption = correctOptions[0];
+    expect(correctOption.id).toBe('country-3');
+    expect(correctOption.text).toBe('Germany');
+
+    // Check that there are 3 incorrect options
+    const incorrectOptions = question.options.filter(option => !option.isCorrect);
+    expect(incorrectOptions.length).toBe(3);
+    
+    // Check that incorrect options contain the expected countries
+    const incorrectCountryNames = incorrectOptions.map(option => option.text);
+    expect(incorrectCountryNames).toEqual(expect.arrayContaining(['France', 'Belgium', 'Italy']));
+    
+    // Check that metadata is correctly set
+    expect(question.metadata).toBeDefined();
+    expect(question.metadata?.allCorrectCountryNames).toEqual(['Germany']);
+    expect(question.metadata?.roadSignId).toBe('roadsign-3');
+  });
+
+  test('should apply both pedestrian and continent filters correctly', async () => {
+    // Mock the RoadSign.aggregate function for this specific test
+    (RoadSign.aggregate as jest.Mock).mockResolvedValue([mockPedestrianRoadSign]);
+
+    // Mock the Country.aggregate function for incorrect European options
+    (Country.aggregate as jest.Mock).mockResolvedValue([
+      {
+        _id: 'country-1',
+        name: 'France',
+        capital: 'Paris',
+        continent: 'Europe',
+        in_geoguessr: true,
+        code: 'fr'
+      },
+      {
+        _id: 'country-2',
+        name: 'Belgium',
+        capital: 'Brussels',
+        continent: 'Europe',
+        in_geoguessr: true,
+        code: 'be'
+      },
+      {
+        _id: 'country-4',
+        name: 'Italy',
+        capital: 'Rome',
+        continent: 'Europe',
+        in_geoguessr: true,
+        code: 'it'
+      }
+    ]);
+
+    // Define filter for both pedestrian signs and Europe continent
+    const filters: QuizFilters = {
+      pedestrian: true,
+      continent: 'Europe'
+    };
+
+    // Call the function being tested with combined filters
+    const question = await getRandomRoadSignQuestion(filters);
+
+    // Assertions
+    expect(question).toBeDefined();
+    expect(question.question).toBe('Which country does this road sign belong to?');
+    expect(question.imageUrl).toBe('https://example.com/roadsign3.jpg');
+    expect(question.options.length).toBe(4);
+    
+    // The correct option should be Germany
+    const correctOption = question.options.find(option => option.isCorrect);
+    expect(correctOption).toBeDefined();
+    expect(correctOption?.id).toBe('country-3');
+    expect(correctOption?.text).toBe('Germany');
+    
+    // Check that the aggregation pipeline was correctly built with both filters
+    expect(RoadSign.aggregate).toHaveBeenCalled();
+    
+    // Check that metadata is correctly set
+    expect(question.metadata).toBeDefined();
+    expect(question.metadata?.allCorrectCountryNames).toEqual(['Germany']);
+    expect(question.metadata?.roadSignId).toBe('roadsign-3');
   });
 }); 

--- a/server/src/tests/roadSignQuizEndpoint.test.ts
+++ b/server/src/tests/roadSignQuizEndpoint.test.ts
@@ -47,6 +47,7 @@ const testRoadSigns: Array<{
   description: string;
   googleMapsUrl: string;
   countries: mongoose.Types.ObjectId[];
+  isPedestrian?: boolean;
 }> = [
   {
     imageUrl: 'https://example.com/roadsign1.jpg',
@@ -59,6 +60,13 @@ const testRoadSigns: Array<{
     description: 'A typical German road sign',
     googleMapsUrl: 'https://maps.google.com/?q=Berlin',
     countries: [] // Will be filled with ObjectIds after countries are inserted
+  },
+  {
+    imageUrl: 'https://example.com/roadsign3.jpg',
+    description: 'A German pedestrian crossing sign',
+    googleMapsUrl: 'https://maps.google.com/?q=Berlin',
+    countries: [], // Will be filled with ObjectIds after countries are inserted
+    isPedestrian: true
   }
 ];
 
@@ -88,6 +96,7 @@ beforeAll(async () => {
   // Update road sign test data with actual country ObjectIds
   testRoadSigns[0].countries = [insertedCountries[0]._id]; // French road sign
   testRoadSigns[1].countries = [insertedCountries[1]._id]; // German road sign
+  testRoadSigns[2].countries = [insertedCountries[1]._id]; // German pedestrian sign
   
   // Insert test road signs
   await RoadSign.insertMany(testRoadSigns);
@@ -224,5 +233,42 @@ describe('Road Sign Quiz API Endpoint', () => {
     expect(result.attempts[0]).toHaveProperty('isCorrect', true);
     expect(result.attempts[0]).toHaveProperty('questionId', question.id);
     expect(result.attempts[0]).toHaveProperty('selectedCountryId', correctOption.id);
+  });
+  
+  test('GET /api/quiz-questions/roadsigns with pedestrian filter - should return a pedestrian sign', async () => {
+    // Add a pedestrian filter to only get pedestrian signs
+    const response = await request(app).get('/api/quiz-questions/roadsigns?pedestrian=true');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('sessionId');
+    expect(response.body).toHaveProperty('question');
+    
+    const question = response.body.question;
+    expect(question).toHaveProperty('id');
+    expect(question).toHaveProperty('imageUrl');
+    expect(question).toHaveProperty('question');
+    expect(question).toHaveProperty('options');
+    
+    // Verify it's a pedestrian sign
+    expect(question.imageUrl).toBe('https://example.com/roadsign3.jpg');
+    
+    // Verify options structure
+    expect(Array.isArray(question.options)).toBe(true);
+    expect(question.options.length).toBeGreaterThan(0);
+    
+    // Find the correct option
+    const correctOption = question.options.find((opt: any) => opt.isCorrect);
+    expect(correctOption).toBeDefined();
+    
+    // The correct country should be Germany since our pedestrian sign is from Germany
+    expect(correctOption.text).toBe('Germany');
+  });
+  
+  test('GET /api/roadsigns/count with pedestrian filter - should count only pedestrian signs', async () => {
+    const response = await request(app).get('/api/roadsigns/count?pedestrian=true');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('success', true);
+    expect(response.body).toHaveProperty('count', 1); // We added 1 pedestrian sign
   });
 }); 


### PR DESCRIPTION
- Introduced a new boolean state for filtering pedestrian signs in the QuizSettingsPage.
- Updated RoadSignGallery and RoadSignsPage to display pedestrian sign indicators.
- Enhanced backend to support pedestrian filtering in quiz questions and road sign count.
- Added tests to validate pedestrian filtering functionality in the quiz API and question generation.