### PR TITLE
feat: add Data Migration Admin page and API for road sign types migration

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import BollardAdmin from './pages/BollardAdmin';
 import LicensePlateAdmin from './pages/LicensePlateAdmin';
 import CountryAdmin from './pages/CountryAdmin';
 import RoadSignAdmin from './pages/RoadSignAdmin';
+import DataMigrationAdmin from './pages/DataMigrationAdmin';
 import Header from './components/Header';
 import LoginPage from './pages/LoginPage';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -111,6 +112,7 @@ const App: React.FC = () => {
                 <Route path="/admin/licenseplates" element={<LicensePlateAdmin />} />
                 <Route path="/admin/countries" element={<CountryAdmin />} />
                 <Route path="/admin/roadsigns" element={<RoadSignAdmin />} />
+                <Route path="/admin/data-migration" element={<DataMigrationAdmin />} />
               </Route>
               
               <Route path="*" element={<NotFoundPage />} />

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -72,6 +72,9 @@ const Header: React.FC = () => {
                   <Link to="/admin/roadsigns" className="block py-1 px-2 hover:bg-blue-700 rounded transition-colors text-sm">
                     Road Sign Admin
                   </Link>
+                  <Link to="/admin/data-migration" className="block py-1 px-2 hover:bg-blue-700 rounded transition-colors text-sm">
+                    Data Migration
+                  </Link>
                 </div>
               </li>
             )}

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -77,6 +77,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         isAdmin: true 
       }));
       
+      // Store API key for admin API calls - using the actual password as the API key
+      // This works because our server apiKeyMiddleware accepts the admin passwords as valid API keys
+      localStorage.setItem('apiKey', password);
+      
       return true;
     }
     
@@ -87,6 +91,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setIsAuthenticated(false);
     setIsAdmin(false);
     localStorage.removeItem('authData');
+    localStorage.removeItem('apiKey'); // Also remove API key on logout
   };
 
   return (

--- a/client/src/pages/DataMigrationAdmin.tsx
+++ b/client/src/pages/DataMigrationAdmin.tsx
@@ -1,0 +1,358 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import useDocumentTitle from '../hooks/useDocumentTitle';
+import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
+
+interface MigrationResult {
+  success: boolean;
+  message: string;
+  migrationResult: {
+    acknowledged: boolean;
+    modifiedCount: number;
+    upsertedId: null;
+    upsertedCount: number;
+    matchedCount: number;
+  };
+  beforeCount: number;
+  afterCount: number;
+  roadSignsBefore: {
+    _id: string;
+    imageUrl: string;
+    description: string;
+    isPedestrian: boolean;
+    types: string[];
+  }[];
+  roadSignsAfter: {
+    _id: string;
+    imageUrl: string;
+    description: string;
+    isPedestrian: boolean;
+    types: string[];
+  }[];
+}
+
+interface RoadSignDebug {
+  _id: string;
+  description: string;
+  isPedestrian: boolean;
+  isPedestrianType: string;
+  types: string[];
+  typesType: string;
+  rawData: string;
+}
+
+interface DebugResponse {
+  success: boolean;
+  count: number;
+  roadSigns: RoadSignDebug[];
+}
+
+const DataMigrationAdmin: React.FC = () => {
+  useDocumentTitle('Data Migration Admin');
+  
+  const { isAuthenticated, isAdmin } = useAuth();
+  const navigate = useNavigate();
+  
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+  const [success, setSuccess] = useState<string>('');
+  const [migrationResult, setMigrationResult] = useState<MigrationResult | null>(null);
+  const [allSigns, setAllSigns] = useState<RoadSignDebug[]>([]);
+  const [debugLoading, setDebugLoading] = useState(false);
+  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+  
+  // Check authentication status on component mount
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/login');
+      return;
+    }
+    
+    if (!isAdmin) {
+      navigate('/');
+      return;
+    }
+  }, [isAuthenticated, isAdmin, navigate]);
+  
+  const handleMigrateTypes = async () => {
+    if (!window.confirm('Are you sure you want to migrate road sign types? This will add a types array field to all road signs based on the isPedestrian field.')) {
+      return;
+    }
+    
+    setLoading(true);
+    setError('');
+    setSuccess('');
+    setMigrationResult(null);
+    
+    try {
+      // Get API key from localStorage
+      const apiKey = localStorage.getItem('apiKey');
+      
+      if (!apiKey) {
+        throw new Error('API key not found. Please log in again.');
+      }
+      
+      const response = await axios.post('/api/roadsigns/migrate-types', {}, {
+        headers: {
+          'X-API-Key': apiKey
+        }
+      });
+      
+      if (response.data.success) {
+        setSuccess('Road sign types migration completed successfully!');
+        setMigrationResult(response.data);
+      } else {
+        throw new Error(response.data.message || 'Failed to migrate road sign types');
+      }
+    } catch (error: any) {
+      console.error('Error migrating road sign types:', error);
+      setError(error.message || 'Failed to migrate road sign types. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchAllSigns = async () => {
+    setDebugLoading(true);
+    setError('');
+    
+    try {
+      const apiKey = localStorage.getItem('apiKey');
+      
+      if (!apiKey) {
+        throw new Error('API key not found. Please log in again.');
+      }
+      
+      const response = await axios.get<DebugResponse>('/api/roadsigns/debug', {
+        headers: {
+          'X-API-Key': apiKey
+        }
+      });
+      
+      if (response.data.success) {
+        setAllSigns(response.data.roadSigns);
+      } else {
+        throw new Error('Failed to fetch road sign data');
+      }
+    } catch (error: any) {
+      console.error('Error fetching road signs:', error);
+      setError(error.message || 'Failed to fetch road sign data. Please try again.');
+    } finally {
+      setDebugLoading(false);
+    }
+  };
+  
+  // Fetch all signs when the component mounts
+  useEffect(() => {
+    if (isAuthenticated && isAdmin) {
+      fetchAllSigns();
+    }
+  }, [isAuthenticated, isAdmin]);
+  
+  const toggleRowExpansion = (id: string) => {
+    if (expandedRowId === id) {
+      setExpandedRowId(null); // collapse if already expanded
+    } else {
+      setExpandedRowId(id); // expand the clicked row
+    }
+  };
+  
+  // Don't render anything if not authenticated or not admin
+  if (!isAuthenticated || !isAdmin) {
+    return null;
+  }
+  
+  return (
+    <div className="max-w-6xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-6">Data Migration Admin</h1>
+      
+      {/* Debug authentication state */}
+      <div className="bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded mb-4">
+        <p><strong>Authentication State:</strong> {isAuthenticated ? 'Authenticated' : 'Not Authenticated'}</p>
+        <p><strong>Admin State:</strong> {isAdmin ? 'Admin' : 'Not Admin'}</p>
+        <p><strong>API Key:</strong> {localStorage.getItem('apiKey') ? 'Present' : 'Missing'}</p>
+      </div>
+      
+      {/* Error and success messages */}
+      {error && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+          {error}
+        </div>
+      )}
+      
+      {success && (
+        <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+          {success}
+        </div>
+      )}
+      
+      {/* Migration section */}
+      <div className="mb-8 p-4 border rounded-lg bg-white shadow">
+        <h2 className="text-xl font-semibold mb-4">Road Sign Types Migration</h2>
+        <p className="mb-4">
+          This migration will convert the <code className="bg-gray-100 px-1 rounded">isPedestrian</code> boolean field 
+          to a new <code className="bg-gray-100 px-1 rounded">types</code> array field for all road signs.
+        </p>
+        <ul className="list-disc ml-6 mb-4">
+          <li>If <code className="bg-gray-100 px-1 rounded">isPedestrian</code> is <strong>true</strong>, 
+          the sign will have <code className="bg-gray-100 px-1 rounded">["pedestrian"]</code> in its types array.</li>
+          <li>If <code className="bg-gray-100 px-1 rounded">isPedestrian</code> is <strong>false</strong>, 
+          the sign will have an empty types array <code className="bg-gray-100 px-1 rounded">[]</code>.</li>
+        </ul>
+        <div className="flex gap-4">
+          <button
+            onClick={handleMigrateTypes}
+            disabled={loading}
+            className={`px-4 py-2 rounded focus:outline-none ${
+              loading
+                ? 'bg-gray-400 cursor-not-allowed'
+                : 'bg-blue-500 hover:bg-blue-600 text-white'
+            }`}
+          >
+            {loading ? 'Migrating...' : 'Migrate Road Sign Types'}
+          </button>
+          <button
+            onClick={fetchAllSigns}
+            disabled={debugLoading}
+            className={`px-4 py-2 rounded focus:outline-none ${
+              debugLoading
+                ? 'bg-gray-400 cursor-not-allowed'
+                : 'bg-green-500 hover:bg-green-600 text-white'
+            }`}
+          >
+            {debugLoading ? 'Loading...' : 'Refresh Signs Data'}
+          </button>
+        </div>
+      </div>
+      
+      {/* Current Database State */}
+      <div className="mb-8 p-4 border rounded-lg bg-white shadow">
+        <h2 className="text-xl font-semibold mb-4">Current Database State</h2>
+        <p className="text-sm text-gray-600 mb-4">Total signs: {allSigns.length}</p>
+        
+        {debugLoading ? (
+          <p className="text-center py-4">Loading signs data...</p>
+        ) : (
+          <div className="max-h-96 overflow-y-auto bg-gray-50 p-2 rounded">
+            <table className="min-w-full">
+              <thead className="bg-gray-100 sticky top-0">
+                <tr>
+                  <th className="px-2 py-2 text-left"></th>
+                  <th className="px-2 py-2 text-left">ID</th>
+                  <th className="px-2 py-2 text-left">Description</th>
+                  <th className="px-2 py-2 text-left">isPedestrian</th>
+                  <th className="px-2 py-2 text-left">isPedestrian Type</th>
+                  <th className="px-2 py-2 text-left">types</th>
+                  <th className="px-2 py-2 text-left">types Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allSigns.map(sign => (
+                  <React.Fragment key={sign._id}>
+                    <tr className="border-t hover:bg-gray-100 cursor-pointer" onClick={() => toggleRowExpansion(sign._id)}>
+                      <td className="px-2 py-2">
+                        <button className="text-blue-500 hover:text-blue-700">
+                          {expandedRowId === sign._id ? '▼' : '▶'}
+                        </button>
+                      </td>
+                      <td className="px-2 py-2 text-xs">{sign._id}</td>
+                      <td className="px-2 py-2">{sign.description}</td>
+                      <td className="px-2 py-2">{String(sign.isPedestrian)}</td>
+                      <td className="px-2 py-2">{sign.isPedestrianType}</td>
+                      <td className="px-2 py-2">{sign.types.join(', ') || 'empty array'}</td>
+                      <td className="px-2 py-2">{sign.typesType}</td>
+                    </tr>
+                    {expandedRowId === sign._id && (
+                      <tr>
+                        <td colSpan={7} className="px-4 py-2 bg-gray-50 border-b">
+                          <div className="overflow-x-auto">
+                            <pre className="text-xs whitespace-pre-wrap bg-gray-100 p-2 rounded">
+                              {sign.rawData}
+                            </pre>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+      
+      {/* Results section */}
+      {migrationResult && (
+        <div className="mb-8 p-4 border rounded-lg bg-white shadow">
+          <h2 className="text-xl font-semibold mb-4">Migration Results</h2>
+          
+          <div className="mb-4">
+            <h3 className="text-lg font-medium mb-2">Statistics</h3>
+            <ul className="bg-gray-50 p-2 rounded">
+              <li><strong>Total documents:</strong> {migrationResult.beforeCount}</li>
+              <li><strong>Matched documents:</strong> {migrationResult.migrationResult.matchedCount}</li>
+              <li><strong>Modified documents:</strong> {migrationResult.migrationResult.modifiedCount}</li>
+            </ul>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <h3 className="text-lg font-medium mb-2">Before Migration</h3>
+              <div className="max-h-60 overflow-y-auto bg-gray-50 p-2 rounded">
+                <table className="min-w-full">
+                  <thead>
+                    <tr>
+                      <th className="px-2 py-1 text-left">ID</th>
+                      <th className="px-2 py-1 text-left">Description</th>
+                      <th className="px-2 py-1 text-left">isPedestrian</th>
+                      <th className="px-2 py-1 text-left">types</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {migrationResult.roadSignsBefore.map(sign => (
+                      <tr key={sign._id} className="border-t">
+                        <td className="px-2 py-1 text-xs">{sign._id}</td>
+                        <td className="px-2 py-1">{sign.description}</td>
+                        <td className="px-2 py-1">{sign.isPedestrian ? 'true' : 'false'}</td>
+                        <td className="px-2 py-1">{sign.types?.join(', ') || 'none'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            
+            <div>
+              <h3 className="text-lg font-medium mb-2">After Migration</h3>
+              <div className="max-h-60 overflow-y-auto bg-gray-50 p-2 rounded">
+                <table className="min-w-full">
+                  <thead>
+                    <tr>
+                      <th className="px-2 py-1 text-left">ID</th>
+                      <th className="px-2 py-1 text-left">Description</th>
+                      <th className="px-2 py-1 text-left">isPedestrian</th>
+                      <th className="px-2 py-1 text-left">types</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {migrationResult.roadSignsAfter.map(sign => (
+                      <tr key={sign._id} className="border-t">
+                        <td className="px-2 py-1 text-xs">{sign._id}</td>
+                        <td className="px-2 py-1">{sign.description}</td>
+                        <td className="px-2 py-1">{sign.isPedestrian ? 'true' : 'false'}</td>
+                        <td className="px-2 py-1">{sign.types?.join(', ') || 'none'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DataMigrationAdmin; 

--- a/server/src/controllers/roadSignController.ts
+++ b/server/src/controllers/roadSignController.ts
@@ -260,4 +260,109 @@ export const getRoadSignCount = async (req: Request, res: Response): Promise<voi
             error: (error as Error).message 
         });
     }
+};
+
+export const migrateRoadSignTypes = async (req: Request, res: Response): Promise<void> => {
+    try {
+        // Get all road signs before migration
+        const roadSignsBefore = await RoadSign.find({});
+        
+        // Log raw data for debugging
+        console.log('Raw signs data before migration:');
+        roadSignsBefore.forEach(sign => {
+            console.log(`ID: ${sign._id}, isPedestrian: ${sign.isPedestrian}, type: ${typeof sign.isPedestrian}`);
+        });
+        
+        // Manually update each document to ensure correct conversion
+        let updateCount = 0;
+        for (const sign of roadSignsBefore) {
+            // Convert boolean to proper array
+            let typesArray: string[] = [];
+            
+            // Check explicitly for boolean true (strict comparison)
+            if (sign.isPedestrian === true) {
+                typesArray = ['pedestrian'];
+                updateCount++;
+            }
+            
+            // Update the document with the new types array
+            await RoadSign.updateOne(
+                { _id: sign._id },
+                { $set: { types: typesArray } }
+            );
+        }
+        
+        // Get all road signs after migration to verify changes
+        const roadSignsAfter = await RoadSign.find({});
+        
+        // Log raw data after migration for debugging
+        console.log('Raw signs data after migration:');
+        roadSignsAfter.forEach(sign => {
+            console.log(`ID: ${sign._id}, isPedestrian: ${sign.isPedestrian}, types: ${sign.types}, type: ${typeof sign.isPedestrian}`);
+        });
+
+        res.status(200).json({
+            success: true,
+            message: 'Road sign types migration completed successfully',
+            migrationResult: {
+                matchedCount: roadSignsBefore.length,
+                modifiedCount: updateCount
+            },
+            beforeCount: roadSignsBefore.length,
+            afterCount: roadSignsAfter.length,
+            roadSignsBefore: roadSignsBefore.map(sign => ({
+                _id: sign._id,
+                imageUrl: sign.imageUrl,
+                description: sign.description.substring(0, 30) + (sign.description.length > 30 ? '...' : ''),
+                isPedestrian: sign.isPedestrian,
+                types: sign.types || []
+            })),
+            roadSignsAfter: roadSignsAfter.map(sign => ({
+                _id: sign._id,
+                imageUrl: sign.imageUrl,
+                description: sign.description.substring(0, 30) + (sign.description.length > 30 ? '...' : ''),
+                isPedestrian: sign.isPedestrian,
+                types: sign.types || []
+            }))
+        });
+    } catch (error) {
+        console.error('Error migrating road sign types:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Error migrating road sign types',
+            error: (error as Error).message
+        });
+    }
+};
+
+// Add a debug function to check the raw data
+export const debugRoadSigns = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const roadSigns = await RoadSign.find({});
+        
+        // Format the results with detailed type information
+        const formattedSigns = roadSigns.map(sign => ({
+            _id: sign._id,
+            description: sign.description,
+            isPedestrian: sign.isPedestrian,
+            isPedestrianType: typeof sign.isPedestrian,
+            types: sign.types || [],
+            typesType: typeof sign.types,
+            // Convert to string for inspection
+            rawData: JSON.stringify(sign.toObject())
+        }));
+        
+        res.status(200).json({
+            success: true,
+            count: roadSigns.length,
+            roadSigns: formattedSigns
+        });
+    } catch (error) {
+        console.error('Error debugging road signs:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Error debugging road signs',
+            error: (error as Error).message
+        });
+    }
 }; 

--- a/server/src/middleware/apiKeyMiddleware.ts
+++ b/server/src/middleware/apiKeyMiddleware.ts
@@ -1,9 +1,26 @@
 import { Request, Response, NextFunction } from 'express';
 
+// Parse admin credentials from environment variables
+// Format for env variables: ADMIN_PASSWORDS=pass1,pass2,pass3
+const parseAdminPasswords = (): string[] => {
+  // Try the array format first
+  const passwords = (process.env.ADMIN_PASSWORDS || '').split(',').filter(p => p.trim());
+  
+  // If no passwords in array format, use the single password format
+  if (passwords.length === 0 && process.env.ADMIN_API_KEY) {
+    return [process.env.ADMIN_API_KEY];
+  }
+  
+  return passwords;
+};
+
+const ADMIN_PASSWORDS = parseAdminPasswords();
+
 export const requireApiKey = (req: Request, res: Response, next: NextFunction): void => {
   const apiKey = req.headers['x-api-key'];
   
-  if (!apiKey || apiKey !== process.env.ADMIN_API_KEY) {
+  // Check if API key is present and matches any of the admin passwords
+  if (!apiKey || !ADMIN_PASSWORDS.includes(apiKey as string)) {
     res.status(401).json({ message: 'Unauthorized' });
     return;
   }

--- a/server/src/models/RoadSign.ts
+++ b/server/src/models/RoadSign.ts
@@ -6,6 +6,7 @@ export interface IRoadSign extends Document {
     googleMapsUrl: string;
     countries: mongoose.Types.ObjectId[];
     isPedestrian: boolean;
+    types: string[];
     createdAt: Date;
     updatedAt: Date;
 }
@@ -33,6 +34,10 @@ const RoadSignSchema: Schema = new Schema({
     isPedestrian: {
         type: Boolean,
         default: false,
+    },
+    types: {
+        type: [String],
+        default: [],
     },
 }, {
     timestamps: true,

--- a/server/src/routes/roadSignRoutes.ts
+++ b/server/src/routes/roadSignRoutes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { uploadRoadSign, createRoadSign, getGeoGuessrCountries, getAllRoadSigns, deleteRoadSign, getRoadSignsByCountry, getRoadSignCount } from '../controllers/roadSignController';
+import { uploadRoadSign, createRoadSign, getGeoGuessrCountries, getAllRoadSigns, deleteRoadSign, getRoadSignsByCountry, getRoadSignCount, migrateRoadSignTypes, debugRoadSigns } from '../controllers/roadSignController';
 import { requireApiKey } from '../middleware/apiKeyMiddleware';
 
 const router = express.Router();
@@ -9,6 +9,8 @@ router.post('/upload', requireApiKey, uploadRoadSign, createRoadSign);
 router.get('/countries', getGeoGuessrCountries);
 router.get('/', getAllRoadSigns);
 router.delete('/:id', requireApiKey, deleteRoadSign);
+router.post('/migrate-types', requireApiKey, migrateRoadSignTypes);
+router.get('/debug', requireApiKey, debugRoadSigns);
 
 // Public routes
 router.get('/count', getRoadSignCount);


### PR DESCRIPTION
- Introduced a new Data Migration Admin page for managing road sign types migration.
- Implemented backend functionality to migrate road sign types based on the isPedestrian field.
- Updated routing to include the new admin page and added links in the Header component.
- Enhanced AuthContext to manage API key storage and removal on logout.
- Modified RoadSign model to include a types array for storing road sign types.